### PR TITLE
#5 Simplify db connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,8 +127,11 @@ dependencies = [
  "actix-web",
  "chrono",
  "diesel",
+ "diesel_migrations",
  "dotenv",
  "futures",
+ "log",
+ "once_cell",
  "serde",
  "serde_json",
 ]
@@ -521,6 +524,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "diesel_migrations"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf3cde8413353dc7f5d72fa8ce0b99a560a359d2c5ef1e5817ca731cd9008f4c"
+dependencies = [
+ "migrations_internals",
+ "migrations_macros",
 ]
 
 [[package]]
@@ -946,6 +959,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
+name = "migrations_internals"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b4fc84e4af020b837029e017966f86a1c2d5e83e64b589963d5047525995860"
+dependencies = [
+ "diesel",
+]
+
+[[package]]
+name = "migrations_macros"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9753f12909fd8d923f75ae5c3258cae1ed3c8ec052e1b38c93c21a6d157f789c"
+dependencies = [
+ "migrations_internals",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1042,6 +1076,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
 name = "opaque-debug"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,10 @@ edition = "2018"
 actix-web = "3"
 chrono = {version = "0.4", features = ["serde"] }
 diesel = { version = "1.4.4", features = ["postgres", "chrono", "r2d2"] }
+diesel_migrations = "1.4.0"
 dotenv = "0.15.0"
 futures = "0.3.13"
+log = "0.4.14"
+once_cell = "1.7.2"
 serde = "1.0.125"
 serde_json = "1.0.64"

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ $ make watch
     │   │   ├── mod.rs
     │   │   └── views.rs
     │   └── ...
-    ├── config.rs
     ├── db.rs
     ├── main.rs
     ├── schema.rs

--- a/src/apps/companies/views.rs
+++ b/src/apps/companies/views.rs
@@ -2,7 +2,6 @@ use actix_web::{http::header, web, Error, HttpRequest, HttpResponse};
 use serde::{Deserialize, Serialize};
 
 use crate::apps::companies::models;
-use crate::db::DbPool;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CreateCompany {
@@ -14,25 +13,21 @@ pub struct UpdateCompany {
     pub name: Option<String>,
 }
 
-// TODO get connection from pool on middleware
-pub async fn list(pool: web::Data<DbPool>) -> Result<HttpResponse, Error> {
-    let conn = pool.get().expect("couldn't get db connection from pool");
-    Ok(web::block(move || models::Company::all(&conn))
+pub async fn list() -> Result<HttpResponse, Error> {
+    Ok(web::block(move || models::Company::all())
         .await
         .map(|items| HttpResponse::Ok().json(items))
         .map_err(|_| HttpResponse::InternalServerError())?)
 }
 
 pub async fn create(
-    pool: web::Data<DbPool>,
     json: web::Json<CreateCompany>,
     request: HttpRequest,
 ) -> Result<HttpResponse, Error> {
-    let conn = pool.get().expect("couldn't get db connection from pool");
     let item = models::CreateCompany {
         name: json.into_inner().name,
     };
-    Ok(web::block(move || item.create(&conn))
+    Ok(web::block(move || item.create())
         .await
         .map(|item| {
             let url = request.url_for("company-detail", &[item.id.to_string()]);
@@ -47,12 +42,10 @@ pub async fn create(
 }
 
 pub async fn update(
-    pool: web::Data<DbPool>,
     web::Path(id): web::Path<i32>,
     json: web::Json<UpdateCompany>,
 ) -> Result<HttpResponse, Error> {
-    let conn = pool.get().expect("couldn't get db connection from pool");
-    let item = web::block(move || models::Company::id(&conn, id))
+    let item = web::block(move || models::Company::id(id))
         .await
         .map_err(|e| {
             eprintln!("{}", e);
@@ -60,26 +53,19 @@ pub async fn update(
         })?;
 
     match item {
-        Some(item) => {
-            let conn = pool.get().expect("couldn't get db connection from pool");
-            Ok(web::block(move || item.update(&conn, &json.into_inner()))
-                .await
-                .map(|item| HttpResponse::Ok().json(item))
-                .map_err(|e| {
-                    eprintln!("{}", e);
-                    HttpResponse::InternalServerError().finish()
-                })?)
-        }
+        Some(item) => Ok(web::block(move || item.update(&json.into_inner()))
+            .await
+            .map(|item| HttpResponse::Ok().json(item))
+            .map_err(|e| {
+                eprintln!("{}", e);
+                HttpResponse::InternalServerError().finish()
+            })?),
         None => Ok(HttpResponse::NotFound().finish()),
     }
 }
 
-pub async fn retrieve(
-    pool: web::Data<DbPool>,
-    web::Path(id): web::Path<i32>,
-) -> Result<HttpResponse, Error> {
-    let conn = pool.get().expect("couldn't get db connection from pool");
-    Ok(web::block(move || models::Company::id(&conn, id))
+pub async fn retrieve(web::Path(id): web::Path<i32>) -> Result<HttpResponse, Error> {
+    Ok(web::block(move || models::Company::id(id))
         .await
         .map(|item| match item {
             Some(v) => HttpResponse::Ok().json(v),
@@ -88,12 +74,8 @@ pub async fn retrieve(
         .map_err(|_| HttpResponse::InternalServerError())?)
 }
 
-pub async fn destroy(
-    pool: web::Data<DbPool>,
-    web::Path(id): web::Path<i32>,
-) -> Result<HttpResponse, Error> {
-    let conn = pool.get().expect("couldn't get db connection from pool");
-    let item = web::block(move || models::Company::id(&conn, id))
+pub async fn destroy(web::Path(id): web::Path<i32>) -> Result<HttpResponse, Error> {
+    let item = web::block(move || models::Company::id(id))
         .await
         .map_err(|e| {
             eprintln!("{}", e);
@@ -101,16 +83,13 @@ pub async fn destroy(
         })?;
 
     match item {
-        Some(item) => {
-            let conn = pool.get().expect("couldn't get db connection from pool");
-            Ok(web::block(move || item.delete(&conn))
-                .await
-                .map(|_| HttpResponse::NoContent().finish())
-                .map_err(|e| {
-                    eprintln!("{}", e);
-                    HttpResponse::InternalServerError().finish()
-                })?)
-        }
+        Some(item) => Ok(web::block(move || item.delete())
+            .await
+            .map(|_| HttpResponse::NoContent().finish())
+            .map_err(|e| {
+                eprintln!("{}", e);
+                HttpResponse::InternalServerError().finish()
+            })?),
         None => Ok(HttpResponse::NotFound().finish()),
     }
 }

--- a/src/apps/mod.rs
+++ b/src/apps/mod.rs
@@ -1,27 +1,12 @@
-use std::sync::Mutex;
-
-use crate::config;
-use actix_web::{web, HttpResponse, Responder};
+use actix_web::{HttpResponse, Responder};
 
 pub mod companies;
 pub mod users;
 
-pub struct AppStateWithCounter {
-    pub counter: Mutex<i32>, // <- Mutex is necessary to mutate safely across threads
-}
-
-pub async fn hello(data: web::Data<config::AppState>) -> impl Responder {
-    let app_name = &data.app_name;
-    HttpResponse::Ok().body(format!("Hello {}!", app_name))
+pub async fn hello() -> impl Responder {
+    HttpResponse::Ok().body(String::from("Hello actix-web2-rest-api!"))
 }
 
 pub async fn echo(req_body: String) -> impl Responder {
     HttpResponse::Ok().body(req_body)
-}
-
-pub async fn countup(data: web::Data<AppStateWithCounter>) -> impl Responder {
-    let mut counter = data.counter.lock().unwrap(); // <- get counter's MutexGuard
-    *counter += 1; // <- access counter inside MutexGuard
-
-    HttpResponse::Ok().body(format!("{}", counter))
 }

--- a/src/apps/users/models.rs
+++ b/src/apps/users/models.rs
@@ -1,8 +1,8 @@
-use diesel::pg::PgConnection;
 use diesel::prelude::*;
 use diesel::result::Error;
 use serde::{Deserialize, Serialize};
 
+use crate::db;
 use crate::schema::users;
 
 #[derive(Queryable, Debug, Serialize, Deserialize)]
@@ -22,39 +22,38 @@ pub struct CreateUser {
 }
 
 impl User {
-    pub fn all(connection: &PgConnection) -> Result<Vec<Self>, Error> {
+    pub fn all() -> Result<Vec<Self>, Error> {
         use crate::schema::users::dsl::users;
-        let items = users.load::<Self>(connection)?;
+        let items = users.load::<Self>(&db::connect())?;
         Ok(items)
     }
 
-    pub fn id(connection: &PgConnection, id: i32) -> Result<Option<Self>, Error> {
+    pub fn id(id: i32) -> Result<Option<Self>, Error> {
         use crate::schema::users::dsl::users;
-        let item = users.find(id).get_result::<Self>(connection).optional()?;
+        let item = users
+            .find(id)
+            .get_result::<Self>(&db::connect())
+            .optional()?;
         Ok(item)
     }
 
-    pub fn id_with_company_id(
-        connection: &PgConnection,
-        id: i32,
-        company_id: i32,
-    ) -> Result<Option<Self>, Error> {
+    pub fn id_with_company_id(id: i32, company_id: i32) -> Result<Option<Self>, Error> {
         use crate::schema::users::dsl;
         let item = dsl::users
             .find(id)
             .filter(dsl::company_id.eq(company_id))
-            .get_result::<Self>(connection)
+            .get_result::<Self>(&db::connect())
             .optional()?;
         Ok(item)
     }
 }
 
 impl CreateUser {
-    pub fn create(&self, connection: &PgConnection) -> Result<User, Error> {
+    pub fn create(&self) -> Result<User, Error> {
         use crate::schema::users::dsl::users;
         let item = diesel::insert_into(users)
             .values(self)
-            .get_result::<User>(connection)?;
+            .get_result::<User>(&db::connect())?;
         Ok(item)
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,0 @@
-pub struct AppState {
-    pub app_name: String,
-}

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,3 +1,5 @@
+embed_migrations!();
+
 use std::env;
 
 use diesel::pg::PgConnection;
@@ -6,8 +8,6 @@ use once_cell::sync::Lazy;
 
 pub type DbPool = r2d2::Pool<ConnectionManager<PgConnection>>;
 pub type DbConnection = r2d2::PooledConnection<ConnectionManager<PgConnection>>;
-
-embed_migrations!();
 
 static DBPOOL: Lazy<DbPool> = Lazy::new(|| {
     let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");

--- a/src/db.rs
+++ b/src/db.rs
@@ -2,17 +2,30 @@ use std::env;
 
 use diesel::pg::PgConnection;
 use diesel::r2d2::{self, ConnectionManager};
-use dotenv::dotenv;
+use once_cell::sync::Lazy;
 
 pub type DbPool = r2d2::Pool<ConnectionManager<PgConnection>>;
+pub type DbConnection = r2d2::PooledConnection<ConnectionManager<PgConnection>>;
 
-pub fn create_connection_pool() -> DbPool {
-    dotenv().ok();
+embed_migrations!();
 
+static DBPOOL: Lazy<DbPool> = Lazy::new(|| {
     let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
     let manager = ConnectionManager::<PgConnection>::new(database_url);
-    return r2d2::Pool::builder()
+    let pool = r2d2::Pool::builder()
         .max_size(4)
         .build(manager)
         .expect("Failed to create DB connection pool.");
+    pool
+});
+
+pub fn init() {
+    info!("Initializing DB");
+    let conn = connect();
+    embedded_migrations::run_with_output(&conn, &mut std::io::stdout())
+        .expect("Failed to run database migrations.");
+}
+
+pub fn connect() -> DbConnection {
+    return DBPOOL.get().expect("couldn't get db connection from pool.");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,19 @@
 #[macro_use]
 extern crate diesel;
+#[macro_use]
+extern crate diesel_migrations;
 extern crate dotenv;
+#[macro_use]
+extern crate log;
 
 mod apps;
-mod config;
 mod db;
 mod schema;
 mod server;
 
+use dotenv::dotenv;
+
 fn main() -> std::io::Result<()> {
+    dotenv().ok();
     server::run()
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,9 +1,6 @@
-use std::sync::Mutex;
-
 use actix_web::{web, App, HttpServer};
 
 use crate::apps;
-use crate::config;
 use crate::db;
 
 pub fn routes(cfg: &mut web::ServiceConfig) {
@@ -33,26 +30,16 @@ pub fn routes(cfg: &mut web::ServiceConfig) {
             .route(web::get().to(apps::companies::views::list))
             .route(web::post().to(apps::companies::views::create)),
     )
-    .route("/countup", web::get().to(apps::countup))
     .route("/echo", web::get().to(apps::echo))
     .route("/", web::get().to(apps::hello));
 }
 
 #[actix_web::main]
 pub async fn run() -> std::io::Result<()> {
-    let counter = web::Data::new(apps::AppStateWithCounter {
-        counter: Mutex::new(0),
-    });
-    HttpServer::new(move || {
-        App::new()
-            .data(config::AppState {
-                app_name: String::from("Actic-web"),
-            })
-            .data(db::create_connection_pool().clone())
-            .app_data(counter.clone())
-            .configure(routes)
-    })
-    .bind("127.0.0.1:8080")?
-    .run()
-    .await
+    db::init();
+
+    HttpServer::new(move || App::new().configure(routes))
+        .bind("127.0.0.1:8080")?
+        .run()
+        .await
 }


### PR DESCRIPTION
Affected from
https://cloudmaker.dev/how-to-create-a-rest-api-in-rust/
https://zenn.dev/frozenlib/articles/lazy_static_to_once_cell

- use diesel_migrations::embedded_migrations
- create dbpool on global constant